### PR TITLE
Fix Qb-core modifications local QBCore = exports['qb-core']:GetCoreObject()

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 - [x] ⚡ FuseBox minigame to PowerOff electricity by [Tinus_NL](https://forum.cfx.re/u/tinus_nl/)
 - [X] 🚐 Work car ( request by @nzkfc )
 - [X] 🏢 Blip building location ( request by @nzkfc )
+- [x] 🐌 Colddown to prevent multispawn vehicle. (30 minutes)
 
 ## Wishlist:
 - [ ] 📌 Blips's in task's
-- [ ] 🐌 Colddown to prevent multispawn vehicle. (30 minutes)
-- [ ] 
+
 
 
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,3 +1,4 @@
+local QBCore = exports['qb-core']:GetCoreObject()
 local isLoggedIn = false
 local LocationsDone = {}
 local PlayerData = {}

--- a/client/main.lua
+++ b/client/main.lua
@@ -28,18 +28,20 @@ end)
 
 
 
+-- // Cold Down vehicle //
 
 function ColdDown()
     Citizen.CreateThread(function()
     QBCore.Functions.Notify("Debug: entro en ColdDown:"..tostring(isColddown) , "error")
     -- 600000 (10 minutos)
-    Citizen.Wait(120000)
+    Citizen.Wait(300000)
     isColddown = false
     QBCore.Functions.Notify("Debug: salgo en ColdDown:"..tostring(isColddown) , "error")
     end)
 end
 
--- // es un vehicle //
+-- // is a job vechile ? //
+
 function isTruckerVehicle(vehicle)
     local retval = false
         if GetEntityModel(vehicle) == GetHashKey(Config.Vehicle) then

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,6 @@ description 'QB-telco'
 version '1.0.0'
 
 shared_scripts { 
-	'@qb-core/import.lua',
 	'config.lua'
 }
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,7 @@
 -- // Finish project //
 local Bail = {}
+local QBCore = exports['qb-core']:GetCoreObject()
+ 
 
 RegisterServerEvent('qb-telco:server:cWJ0ZWxjbw')
 AddEventHandler('qb-telco:server:cWJ0ZWxjbw', function(TaskDones)


### PR DESCRIPTION
```
QBCore BOT
Need to import QBCore? You can use one simple line to do so!

local QBCore = exports['qb-core']:GetCoreObject()
Made by cDev - discord.gg/pdHXz5uk7j
```

Work arround :

Remove from **shared_scripts**  `'@qb-core/import.lua',`
and add on top files, to client and server lua's `local QBCore = exports['qb-core']:GetCoreObject()`